### PR TITLE
SDK v1.6.9, SUT v1.0.4 가이드 및 릴리즈 노트 적용

### DIFF
--- a/en/release-notes-unity-tool.md
+++ b/en/release-notes-unity-tool.md
@@ -1,5 +1,13 @@
 ## Game > Smart Downloader > Release Notes > Unity Tool
 
+### 1.0.4 (2021.07.27) [Download](https://static.toastoven.net/toastcloud/sdk_download/Smart%20Downloader/SUT/v1.0.4/SmartDownloaderUnityTool.zip)
+
+#### Feature Updates
+
+* Unity 최소 지원 버전을 2018.4.0으로 변경
+* Unity 2020.1 이후 버전에서 업로드가 진행되지 않는 문제 수정
+* Unity 2020.2 이후 버전에서 발생하는 Warning 제거
+
 
 ### 1.0.3 (2020.11.24) [Download](https://static.toastoven.net/toastcloud/sdk_download/Smart%20Downloader/SUT/v1.0.3/SmartDownloaderUnityTool.zip)
 

--- a/en/release-notes-unity.md
+++ b/en/release-notes-unity.md
@@ -1,5 +1,11 @@
 ## Game > Smart Downloader > Release Notes > Unity SDK
 
+### 1.6.9 (2021.07.27) [Download SDK](https://static.toastoven.net/toastcloud/sdk_download/Smart%20Downloader/Smart-downloader-1.6.9.unitypackage)
+
+#### Feature Updates
+* Unity 최소 지원 버전을 2018.4.0으로 변경
+* Unity 2020.2 이후 버전에서 발생하는 Warning 제거
+
 
 ### 1.6.8 (2021.04.13) [Download SDK](https://static.toastoven.net/toastcloud/sdk_download/Smart%20Downloader/Smart-downloader-1.6.8.unitypackage)
 

--- a/en/sdk-guide.md
+++ b/en/sdk-guide.md
@@ -11,7 +11,7 @@ Smart Downloader SDK supports Unity engines.
 
 #### Supported Versions
 
-* 2017.4.16 ~ 2020.3.3
+* 2018.4.0 ~ 2021.1.15
 
 #### Supported Platforms
 
@@ -79,6 +79,30 @@ Smart Downloader SDK supports Unity engines.
     <domain includeSubdomains="true">cdn.toastcloud.com</domain>
   </domain-config>
 </network-security-config>
+```
+
+### iOS 네트워크 보안 구성
+
+* CDN을 HTTP로 사용하는 경우 HTTP 허용 설정이 필요합니다.
+
+#### Info.plist 설정
+
+* Info.plist에서 App Transport Security Settings를 추가합니다.
+
+```
+<key>NSAppTransportSecurity</key>
+<dict>
+    <key>NSExceptionDomains</key>
+    <dict>
+        <key>toastcdn.net</key>
+        <dict>
+            <key>NSExceptionAllowsInsecureHTTPLoads</key>
+            <true/>
+            <key>NSIncludesSubdomains</key>
+            <true/>
+        </dict>
+    </dict>
+</dict>
 ```
 
 

--- a/en/sut-guide.md
+++ b/en/sut-guide.md
@@ -8,7 +8,7 @@ Smart Downloader Unity Tool, or SUT is a tool to upload and deploy resources for
 
 #### Supported Unity Versions
 
-* 2017.4.16 ~ 2020.1.14
+* 2018.4.0 ~ 2021.1.15
 
 ### Download
 

--- a/ja/release-notes-unity-tool.md
+++ b/ja/release-notes-unity-tool.md
@@ -1,5 +1,13 @@
 ## Game > Smart Downloader > リリースノート > Unity Tool
 
+### 1.0.4 (2021.07.27) [ダウンロード](https://static.toastoven.net/toastcloud/sdk_download/Smart%20Downloader/SUT/v1.0.4/SmartDownloaderUnityTool.zip)
+
+#### 機能改善/変更
+
+* Unity 최소 지원 버전을 2018.4.0으로 변경
+* Unity 2020.1 이후 버전에서 업로드가 진행되지 않는 문제 수정
+* Unity 2020.2 이후 버전에서 발생하는 Warning 제거
+
 
 ### 1.0.3 (2020.11.24) [ダウンロード](https://static.toastoven.net/toastcloud/sdk_download/Smart%20Downloader/SUT/v1.0.3/SmartDownloaderUnityTool.zip)
 

--- a/ja/release-notes-unity.md
+++ b/ja/release-notes-unity.md
@@ -1,5 +1,11 @@
 ## Game > Smart Downloader > リリースノート > Unity SDK
 
+### 1.6.9 (2021.07.27) [SDKをダウンロード](https://static.toastoven.net/toastcloud/sdk_download/Smart%20Downloader/Smart-downloader-1.6.9.unitypackage)
+
+#### 機能改善/変更
+* Unity 최소 지원 버전을 2018.4.0으로 변경
+* Unity 2020.2 이후 버전에서 발생하는 Warning 제거
+
 
 ### 1.6.8 (2021.04.13) [SDKをダウンロード](https://static.toastoven.net/toastcloud/sdk_download/Smart%20Downloader/Smart-downloader-1.6.8.unitypackage)
 

--- a/ja/sdk-guide.md
+++ b/ja/sdk-guide.md
@@ -11,7 +11,7 @@ Smart Downloader SDKはUnityエンジンをサポートします。
 
 #### Supported Versions
 
-* 2017.4.16 ~ 2020.3.3
+* 2018.4.0 ~ 2021.1.15
 
 #### Supported Platforms
 
@@ -78,6 +78,30 @@ Smart Downloader SDKはUnityエンジンをサポートします。
     <domain includeSubdomains="true">cdn.toastcloud.com</domain>
   </domain-config>
 </network-security-config>
+```
+
+### iOS 네트워크 보안 구성
+
+* CDN을 HTTP로 사용하는 경우 HTTP 허용 설정이 필요합니다.
+
+#### Info.plist 설정
+
+* Info.plist에서 App Transport Security Settings를 추가합니다.
+
+```
+<key>NSAppTransportSecurity</key>
+<dict>
+    <key>NSExceptionDomains</key>
+    <dict>
+        <key>toastcdn.net</key>
+        <dict>
+            <key>NSExceptionAllowsInsecureHTTPLoads</key>
+            <true/>
+            <key>NSIncludesSubdomains</key>
+            <true/>
+        </dict>
+    </dict>
+</dict>
 ```
 
 

--- a/ja/sut-guide.md
+++ b/ja/sut-guide.md
@@ -8,7 +8,7 @@ Smart Downloader Unity Tool(SUT)は、Unityからリソースをアップロー�
 
 #### Unity Supported Versions
 
-* 2017.4.16 ~ 2020.1.14
+* 2018.4.0 ~ 2021.1.15
 
 ### Download
 

--- a/ko/release-notes-unity-tool.md
+++ b/ko/release-notes-unity-tool.md
@@ -1,5 +1,13 @@
 ## Game > Smart Downloader > 릴리스 노트 > Unity Tool
 
+### 1.0.4 (2021.07.27) [다운로드](https://static.toastoven.net/toastcloud/sdk_download/Smart%20Downloader/SUT/v1.0.4/SmartDownloaderUnityTool.zip)
+
+#### 기능 개선/변경
+
+* Unity 최소 지원 버전을 2018.4.0으로 변경
+* Unity 2020.1 이후 버전에서 업로드가 진행되지 않는 문제 수정
+* Unity 2020.2 이후 버전에서 발생하는 Warning 제거
+
 
 ### 1.0.3 (2020.11.24) [다운로드](https://static.toastoven.net/toastcloud/sdk_download/Smart%20Downloader/SUT/v1.0.3/SmartDownloaderUnityTool.zip)
 
@@ -34,5 +42,3 @@ Unity Tool v1.0.2 이하 버전을 사용하시는 경우 업데이트가 필요
 
 
 * 배포
-
-

--- a/ko/release-notes-unity.md
+++ b/ko/release-notes-unity.md
@@ -1,5 +1,11 @@
 ## Game > Smart Downloader > 릴리스 노트 > Unity SDK
 
+### 1.6.9 (2021.07.27) [SDK 다운로드](https://static.toastoven.net/toastcloud/sdk_download/Smart%20Downloader/Smart-downloader-1.6.9.unitypackage)
+
+#### 기능 개선/변경
+* Unity 최소 지원 버전을 2018.4.0으로 변경
+* Unity 2020.2 이후 버전에서 발생하는 Warning 제거
+
 
 ### 1.6.8 (2021.04.13) [SDK 다운로드](https://static.toastoven.net/toastcloud/sdk_download/Smart%20Downloader/Smart-downloader-1.6.8.unitypackage)
 

--- a/ko/sdk-guide.md
+++ b/ko/sdk-guide.md
@@ -11,7 +11,7 @@ Smart Downloader SDK는 유니티 엔진을 지원합니다.
 
 #### Supported Versions
 
-* 2017.4.16 ~ 2020.3.3
+* 2018.4.0 ~ 2021.1.15
 
 #### Supported Platforms
 
@@ -78,6 +78,30 @@ Smart Downloader SDK는 유니티 엔진을 지원합니다.
     <domain includeSubdomains="true">cdn.toastcloud.com</domain>
   </domain-config>
 </network-security-config>
+```
+
+### iOS 네트워크 보안 구성
+
+* CDN을 HTTP로 사용하는 경우 HTTP 허용 설정이 필요합니다.
+
+#### Info.plist 설정
+
+* Info.plist에서 App Transport Security Settings를 추가합니다.
+
+```
+<key>NSAppTransportSecurity</key>
+<dict>
+    <key>NSExceptionDomains</key>
+    <dict>
+        <key>toastcdn.net</key>
+        <dict>
+            <key>NSExceptionAllowsInsecureHTTPLoads</key>
+            <true/>
+            <key>NSIncludesSubdomains</key>
+            <true/>
+        </dict>
+    </dict>
+</dict>
 ```
 
 

--- a/ko/sut-guide.md
+++ b/ko/sut-guide.md
@@ -8,7 +8,7 @@ Smart Downloader Unity Tool(SUT)은 Unity에서 리소스를 업로드하고 배
 
 #### Unity Supported Versions
 
-* 2017.4.16 ~ 2020.1.14
+* 2018.4.0 ~ 2021.1.15
 
 ### Download
 

--- a/zh/release-notes-unity-tool.md
+++ b/zh/release-notes-unity-tool.md
@@ -1,5 +1,13 @@
 ## Game > Smart Downloader > Release Notes > Unity Tool
 
+### 1.0.4 (2021.07.27) [Download](https://static.toastoven.net/toastcloud/sdk_download/Smart%20Downloader/SUT/v1.0.4/SmartDownloaderUnityTool.zip)
+
+#### Feature Updates
+
+* Unity 최소 지원 버전을 2018.4.0으로 변경
+* Unity 2020.1 이후 버전에서 업로드가 진행되지 않는 문제 수정
+* Unity 2020.2 이후 버전에서 발생하는 Warning 제거
+
 
 ### 1.0.3 (2020.11.24) [Download](https://static.toastoven.net/toastcloud/sdk_download/Smart%20Downloader/SUT/v1.0.3/SmartDownloaderUnityTool.zip)
 

--- a/zh/release-notes-unity.md
+++ b/zh/release-notes-unity.md
@@ -1,5 +1,11 @@
 ## Game > Smart Downloader > Release Notes > Unity SDK
 
+### 1.6.9 (2021.07.27) [Download SDK](https://static.toastoven.net/toastcloud/sdk_download/Smart%20Downloader/Smart-downloader-1.6.9.unitypackage)
+
+#### Feature Updates
+* Unity 최소 지원 버전을 2018.4.0으로 변경
+* Unity 2020.2 이후 버전에서 발생하는 Warning 제거
+
 
 ### 1.6.8 (2021.04.13) [Download SDK](https://static.toastoven.net/toastcloud/sdk_download/Smart%20Downloader/Smart-downloader-1.6.8.unitypackage)
 

--- a/zh/sdk-guide.md
+++ b/zh/sdk-guide.md
@@ -11,7 +11,7 @@ Smart Downloader SDK supports Unity engines.
 
 #### Supported Versions
 
-* 2017.4.16 ~ 2020.3.3
+* 2018.4.0 ~ 2021.1.15
 
 #### Supported Platforms
 
@@ -78,6 +78,30 @@ Smart Downloader SDK supports Unity engines.
     <domain includeSubdomains="true">cdn.toastcloud.com</domain>
   </domain-config>
 </network-security-config>
+```
+
+### iOS 네트워크 보안 구성
+
+* CDN을 HTTP로 사용하는 경우 HTTP 허용 설정이 필요합니다.
+
+#### Info.plist 설정
+
+* Info.plist에서 App Transport Security Settings를 추가합니다.
+
+```
+<key>NSAppTransportSecurity</key>
+<dict>
+    <key>NSExceptionDomains</key>
+    <dict>
+        <key>toastcdn.net</key>
+        <dict>
+            <key>NSExceptionAllowsInsecureHTTPLoads</key>
+            <true/>
+            <key>NSIncludesSubdomains</key>
+            <true/>
+        </dict>
+    </dict>
+</dict>
 ```
 
 

--- a/zh/sut-guide.md
+++ b/zh/sut-guide.md
@@ -8,7 +8,7 @@ Smart Downloader Unity Tool, or SUT is a tool to upload and deploy resources for
 
 #### Supported Unity Versions
 
-* 2017.4.16 ~ 2020.1.14
+* 2018.4.0 ~ 2021.1.15
 
 ### Download
 


### PR DESCRIPTION
## SDK v1.6.9, SUT v1.0.4 가이드 및 릴리즈 노트 적용

* 업무 내용 정리
    * 릴리즈 노트 추가
    * Unity 지원 버전 업데이트
    * SDK iOS HTTP 허용 설정 가이드 추가